### PR TITLE
update pandoc install

### DIFF
--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -12,10 +12,9 @@ jobs:
       - name: Setup R
         uses: r-lib/actions/setup-r@master
 
-      - name: Install pandoc and pandoc citeproc
+      - name: Install pandoc
         run: |
           brew install pandoc
-          brew install pandoc-citeproc
 
       - name: Cache Renv packages
         uses: actions/cache@v1


### PR DESCRIPTION
Hi Emil! Thanks for the awesome tutorial.

As I was working through this for my own use case, I ran into an Actions issue:

```
==> Summary
🍺  /usr/local/Cellar/pandoc/2.11.4: 10 files, 146.0MB
Error: pandoc-citeproc has been disabled because it is deprecated upstream!
Error: Process completed with exit code 1.
```

Turns out that `pandoc-citeproc` comes with `pandoc` proper now, so no need for the extra install. Thought I'd drop the fix ([from `r-lib/actions`](https://github.com/r-lib/actions/commit/be21f25befae7871c7b45ddbc00e116a0bd27e34)) here as well for other folks who start with your example repo rather than the `usethis` workflow. :-)